### PR TITLE
Before failure fix

### DIFF
--- a/cypress/integration/before-error-spec.js
+++ b/cypress/integration/before-error-spec.js
@@ -1,0 +1,25 @@
+/// <reference types="cypress"/>
+
+describe("Exception in before block", () => {
+  describe("Broken case", () => {
+    before(() => {
+      Cypress.currentTest.retries(1);
+      throw new Error("This is the real error!");
+    });
+  
+    it("shouldn't run this test", () => {
+      cy.get("#someSelector").should("be.visible");
+    });
+  });
+
+  describe("Working case", () => {
+    before(() => {
+      Cypress.currentTest.retries(0);
+      throw new Error("This is the real error!");
+    });
+  
+    it("shouldn't run this test", () => {
+      cy.get("#someSelector").should("be.visible");
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ Cypress.runner.onRunnableRun = function(runnableRun, runnable, args) {
   const isHook = r.type === 'hook'
   const isAfterHook = isHook && r.hookName.match(/after/)
   const isAfterAllHook = isHook && r.hookName.match(/after all/)
-  const isBeforeHook = isHook && r.hookName.match(/before/)
+  const isBeforeHook = isHook && r.hookName.match(/before each/)
   const test = r.ctx.currentTest || r
 
   if (test._currentRetry === 0 && logs.testId !== test.id) {


### PR DESCRIPTION
@Bkucera This fixes https://github.com/Bkucera/cypress-plugin-retries/issues/20

You can see with the demonstration test (same test linked in that issue) that it now fails with the correct error both times and all existing tests in this repo are passing.

I have tried writing a test that captures this issue but passes, I haven't been successful and have run out of time and need to get back to company work.

If you're okay with the fix not having tests associated, the demonstration test can be dropped and merging this will fix the issue.  Otherwise, feel free to write some better tests :)