### PR TITLE
chore(docs): Add usage - Set environment variable in cypress.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ CYPRESS_RETRIES=2 npm run cypress
 ```js
 Cypress.env('RETRIES', 2)
 ```
+**or** Set the `"env"` in your `cypress.json` file to set the retry number for **all tests**: 
+```json
+{
+  ...
+  "env":
+  {
+    "retries": 2
+  }
+}
+```
 **or** On a per-test or per-hook basis, set the retry number:
 > Note: this plugin **adds Cypress.currentTest** and you should only access it in the context of this plugin.
 ```js

--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ CYPRESS_RETRIES=2 npm run cypress
 ```js
 Cypress.env('RETRIES', 2)
 ```
-**or** Set the `"env"` in your `cypress.json` file to set the retry number for **all tests**: 
+**or** Set the `"env"` key in your `cypress.json` configuration file to set the retry number for **all tests**: 
 ```json
 {
-  ...
   "env":
   {
     "retries": 2


### PR DESCRIPTION
I've added an additional usage of this package. We can set the environment variable in `cypress.json` in addition to the other usages stated in the README.

I just tried this usage today and it worked.