### PR TITLE
fix(types): type checking declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.2",
   "description": "Cypress plugin allowing tests to retry a configurable amount of times",
   "main": "lib/support",
+  "types": "lib/index.d.ts",
   "scripts": {
     "lint": "eslint --ext json,js,ts .",
     "test": "cypress run --spec '**/unit/**'",


### PR DESCRIPTION
In version 1.5.0, `main` was changed to point to `lib/support` instead of `src` which broke type checking so in order to make it work with the current package configuration, we need to explicitly indicate the main types declaration file:

before:
```json
...
"main": "lib/support",
...
```

after
```json
...
  "main": "lib/support",
  "types": "lib/index.d.ts",
...
```