### PR TITLE
Add missing property currentRetry on currentTest

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -5,7 +5,7 @@
 					/**
 					 * Gets the current test. Added by cypress-plugin-retries
 					 */
-					currentTest: Mocha.ISuiteCallbackContext & {
+					currentTest: Mocha.Test & {
 							currentRetry: () => number
 					}
 			}

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -5,6 +5,8 @@
 					/**
 					 * Gets the current test. Added by cypress-plugin-retries
 					 */
-					currentTest: Mocha.ISuiteCallbackContext
+					currentTest: Mocha.ISuiteCallbackContext & {
+							currentRetry: () => number
+					}
 			}
 	}


### PR DESCRIPTION
Hello 👋 ,

noticed the currentRetry property definition is missing (not present in Mocha.ISuiteCallbackContext)